### PR TITLE
feat: Sign on the black X

### DIFF
--- a/client/src/components/MailInserts.tsx
+++ b/client/src/components/MailInserts.tsx
@@ -152,12 +152,22 @@ const SignatureLine = styled.div`
   margin: 0.025in 0.05in;
   padding-top: 0.025in;
   font-size: 8pt;
+  &::after,
   &::before {
-    content: '✖️';
+    content: '';
+    display: block;
     position: absolute;
-    top: -20pt;
-    font-size: 20pt;
-    left: -4pt;
+    bottom: 12pt;
+    left: 5pt;
+    width: 2pt;
+    height: 14pt;
+    border-right: 2pt solid #000000;
+  }
+  &::before {
+    transform: rotate(45deg);
+  }
+  &::after {
+    transform: rotate(-45deg);
   }
 `
 const DateLine = styled.div`


### PR DESCRIPTION
Instead of using the multiplication character, use two html elements with borders positioned into an "X".

Using borders will ensure that this works without "print background images" enabled.

![image](https://user-images.githubusercontent.com/28444/88085172-5900fc80-cb3a-11ea-9310-068859095d24.png)
